### PR TITLE
chore(deps): Add ruff to dev deps, update gha to suit #32

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Upgrade pip and install dependencies
         run: |
-          pip install --upgrade pip setuptools ruff
+          pip install --upgrade pip setuptools
           pip install -e ".[dev]"
 
       - name: Code formatting check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
   'pytest-cov == 4.0.0',
   'pytest-django == 4.5.2',
   'pytest-mock == 3.10.0',
+  'ruff == 0.3.7',
   'safety == 2.3.5',
   'types-setuptools == 65.6.0.2',
   'typing_extensions == 4.9.0',


### PR DESCRIPTION
Moved ruff into the deps so that it can be run locally without the need to install it separately. Removed the separate installation of ruff from the gha lint.

closes #32