### PR TITLE
chore(git): Fix linter coverage reporting #45

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -33,17 +33,9 @@ jobs:
       - name: Type checking with mypy
         run: mypy --non-interactive .
 
-      - name: Copy CKEditor files
-        run: cp -R django_ckeditors example/blog
-
-      - name: Change directory to example
-        run: cd example
-
-      - name: Install dependencies in example
-        run: pip install -e ".[dev]"
-
       - name: Run tests with pytest
-        run: pytest example/blog
+        run: |
+          pytest example/blog
 
       - name: Print Python version
         run: python --version


### PR DESCRIPTION
Linter was installing multiple of the same environment, and directory changes in the workflow broke the coverage reporting.

closes #45