### PR TITLE
chore(img): Add image processing option #49

### DIFF
--- a/django_ckeditors/apps.py
+++ b/django_ckeditors/apps.py
@@ -1,10 +1,9 @@
 """django-ckeditors app.py file"""
 from __future__ import annotations
 
-import sys
-import django
 from django.apps import AppConfig
 from django.conf import settings
+
 
 class DjangoCKEditorsConfig(AppConfig):
     name = "django_ckeditors"
@@ -12,7 +11,6 @@ class DjangoCKEditorsConfig(AppConfig):
     def ready(self):
         # Unsure as to why this was used originally,
         # but here it is just in case.
-        print('#################  UPDATED')
         if not hasattr(settings, "DJ_CKE_CSRF_COOKIE_NAME"):
             settings.DJ_CKE_CSRF_COOKIE_NAME: str = settings.CSRF_COOKIE_NAME  # type: ignore[attr-defined]
 
@@ -27,18 +25,10 @@ class DjangoCKEditorsConfig(AppConfig):
             ]
 
         if not hasattr(settings, "DJ_CKE_CUSTOM_CSS"):
-            settings.DJ_CKE_CUSTOM_CSS: Versionstr = ""  # type: ignore[attr-defined]
+            settings.DJ_CKE_CUSTOM_CSS: str = ""  # type: ignore[attr-defined]
 
-        if django.VERSION >= (3,2,9) and sys.version_info >= (3,10):
-            if not hasattr(settings, "DJ_CKE_IMAGE_FORMATTER"):
-                # settings.DJ_CKE_IMAGE_FORMATTER: str = "django_ckeditors.image.image_formatter"  # type: ignore[attr-defined]
-                settings.DJ_CKE_IMAGE_FORMATTER=''
-            if not hasattr(settings, "DJ_CKE_IMAGE_SAVE_FILE_TYPE"):
-                settings.DJ_CKE_IMAGE_SAVE_FILE_TYPE: str = "webp"  # type: ignore[attr-defined]
-            if not hasattr(settings, "DJ_CKE_IMAGE_SAVE_QUALITY"):
-                settings.DJ_CKE_IMAGE_SAVE_QUALITY: int = None  # type: ignore[attr-defined]
-        else:
-            settings.DJ_CKE_IMAGE_FORMATTER: str = "" # type: ignore[attr-defined]
+        if not hasattr(settings, "DJ_CKE_IMAGE_FORMATTER"):
+            settings.DJ_CKE_IMAGE_FORMATTER = ""
 
         if not hasattr(settings, "DJ_CKE_IMAGE_URL_HANDLER"):
             settings.DJ_CKE_IMAGE_URL_HANDLER: str = ""  # type: ignore[attr-defined]

--- a/django_ckeditors/apps.py
+++ b/django_ckeditors/apps.py
@@ -1,9 +1,10 @@
 """django-ckeditors app.py file"""
 from __future__ import annotations
 
+import sys
+import django
 from django.apps import AppConfig
 from django.conf import settings
-
 
 class DjangoCKEditorsConfig(AppConfig):
     name = "django_ckeditors"
@@ -11,6 +12,7 @@ class DjangoCKEditorsConfig(AppConfig):
     def ready(self):
         # Unsure as to why this was used originally,
         # but here it is just in case.
+        print('#################  UPDATED')
         if not hasattr(settings, "DJ_CKE_CSRF_COOKIE_NAME"):
             settings.DJ_CKE_CSRF_COOKIE_NAME: str = settings.CSRF_COOKIE_NAME  # type: ignore[attr-defined]
 
@@ -25,7 +27,18 @@ class DjangoCKEditorsConfig(AppConfig):
             ]
 
         if not hasattr(settings, "DJ_CKE_CUSTOM_CSS"):
-            settings.DJ_CKE_CUSTOM_CSS: str = ""  # type: ignore[attr-defined]
+            settings.DJ_CKE_CUSTOM_CSS: Versionstr = ""  # type: ignore[attr-defined]
+
+        if django.VERSION >= (3,2,9) and sys.version_info >= (3,10):
+            if not hasattr(settings, "DJ_CKE_IMAGE_FORMATTER"):
+                # settings.DJ_CKE_IMAGE_FORMATTER: str = "django_ckeditors.image.image_formatter"  # type: ignore[attr-defined]
+                settings.DJ_CKE_IMAGE_FORMATTER=''
+            if not hasattr(settings, "DJ_CKE_IMAGE_SAVE_FILE_TYPE"):
+                settings.DJ_CKE_IMAGE_SAVE_FILE_TYPE: str = "webp"  # type: ignore[attr-defined]
+            if not hasattr(settings, "DJ_CKE_IMAGE_SAVE_QUALITY"):
+                settings.DJ_CKE_IMAGE_SAVE_QUALITY: int = None  # type: ignore[attr-defined]
+        else:
+            settings.DJ_CKE_IMAGE_FORMATTER: str = "" # type: ignore[attr-defined]
 
         if not hasattr(settings, "DJ_CKE_IMAGE_URL_HANDLER"):
             settings.DJ_CKE_IMAGE_URL_HANDLER: str = ""  # type: ignore[attr-defined]

--- a/django_ckeditors/helpers.py
+++ b/django_ckeditors/helpers.py
@@ -153,9 +153,7 @@ def handle_uploaded_image(request):
             formatter = import_string(settings.DJ_CKE_IMAGE_FORMATTER)
             img=formatter(img)
         except TypeError as e:
-     
             raise TypeError from e
-    print('%%%%%%%%%%%%  Helper img upload')
     filename = storage.save(name=url, content=img)
 
     return storage.url(filename)  # Return the URL of the saved image

--- a/django_ckeditors/helpers.py
+++ b/django_ckeditors/helpers.py
@@ -146,9 +146,16 @@ def handle_uploaded_image(request):
         url = url_handler(request)  # Get the URL using the custom handler
 
     else:
-
         url = img.name  # Default to using the image's filename as the URL
 
+    if settings.DJ_CKE_IMAGE_FORMATTER:
+        try:
+            formatter = import_string(settings.DJ_CKE_IMAGE_FORMATTER)
+            img=formatter(img)
+        except TypeError as e:
+     
+            raise TypeError from e
+    print('%%%%%%%%%%%%  Helper img upload')
     filename = storage.save(name=url, content=img)
 
     return storage.url(filename)  # Return the URL of the saved image

--- a/django_ckeditors/image.py
+++ b/django_ckeditors/image.py
@@ -1,0 +1,211 @@
+"""Image tools."""
+
+import io
+from pathlib import Path
+from PIL import Image
+# import pillow_avif  # noqa: F401
+from django.core.exceptions import ValidationError
+from django.core.files.images import ImageFile
+from django.core.files.uploadedfile import UploadedFile
+from django.db.models.fields.files import ImageFieldFile
+from django.utils.translation import gettext_lazy as _
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def image_formatter(
+    image: UploadedFile = None,
+    height: int = None,
+    width: int = None,
+    save_format: str = 'webp',
+    quality: int = None,
+) -> Image.Image:
+    """Take an UploadedFile image and massage it to a suitable web format.
+
+    Params
+    ======
+
+    :param image: `django.core.files.uploadedfile.InMemoryUploadedFile` object.
+    :param save_format: str Options:
+                                AVIF: convert image to .avif format.
+                                WEBP: convert image to .webp format.
+                                JPEG: convert image to .jpg format.
+                                PNG: convert image to .png format.
+    :param quality: int. Optional: 0 to 100 inclusive. Worst to Best quality.
+
+
+    ###############################################
+
+    NOT IMPLEMENTED
+
+    :param height: int. Optional: Height in pixels.
+    :param width: int. Optional: Width in pixels.
+
+    ###############################################
+
+    :raises ValidationError:  When user attempts to upload an unsupported file.
+    :raises TypeError: When an internal error caused by developer mistake
+                    passing incorrect types.
+
+    :returns: UploadedFile
+
+
+    See reference material here https://github.com/trader-biz/britstralian/issues/235
+
+    """
+
+    # if isinstance(image, ImageFieldFile):
+    #     print(f"\n\nCONVERTING IMAGE NOT REQUIRED RETURNING {image}\n\n")
+    #     return image
+
+    save_format=save_format.lower()
+
+    match image:
+        case UploadedFile():
+            uploaded_file_name = Path(image.__dict__["_name"])
+            # supported_image_formats = [
+            #     ".jpg",
+            #     ".jpeg",
+            #     ".jfif",
+            #     ".pjpeg",
+            #     ".pjp",
+            #     ".avif",
+            #     ".png",
+            #     ".webp",
+            # ]
+            #
+            # # Check the uploaded file type is supported.
+            # # We use a validation error here so that feedback can be supplied to the user.
+            # if (
+            #     not uploaded_file_name.suffix.lower()
+            #     in supported_image_formats
+            # ):
+            #     raise ValidationError(
+            #         _(
+            #             "The image format %(save_format)s you have uploaded is not supported. Please use one of %(supported)s"  # noqa: E501
+            #         ),
+            #         params={
+            #             "save_format": uploaded_file_name.suffix,
+            #             "supported": str(supported_image_formats)
+            #             .replace("[", "")
+            #             .replace("]", "")
+            #             .replace("'", "")
+            #             .replace(",", ""),
+            #         },
+            #     )
+
+            img_size = int(image.__dict__["size"])
+            file_extension = ""
+
+            if img_size > 20_000_000:
+                raise ValidationError(
+                    _(
+                        "The image size %(image_size)s Megabits you have uploaded is to large. The maximum image size is 20 Megabits."  # noqa: E501
+                    ),
+                    params={
+                        "image_size": img_size / 1_000_000,
+                    },
+                )
+
+            match save_format:
+                # case None | "AVIF":
+                #     save_format = "AVIF"
+                #     # Determine a suitable quality for the image.
+                #     # Determines the finished file size in bytes. Smaller is better.
+                #     if 500_000 >= img_size:
+                #         quality = 30
+                #     if 500_000 <= img_size <= 1000_000:
+                #         quality = 20
+                #     if 1_000_001 <= img_size <= 2_000_000:
+                #         quality = 10
+                #     if 2_000_001 <= img_size <= 10_000_000:
+                #         quality = 5
+                #     if 10_000_001 <= img_size:
+                #         quality = 3
+                #     file_extension = ".avif"
+
+                case 'webp' |  "jpeg" |  "png":
+                    # Determine a suitable quality for the image.
+                    # Determines the finished file size in bytes. Smaller is better.
+                    if 500_000 >= img_size:
+                        quality = 30
+                    if 500_000 <= img_size <= 1000_000:
+                        quality = 20
+                    if 1_000_001 <= img_size <= 2_000_000:
+                        quality = 10
+                    if 2_000_001 <= img_size <= 10_000_000:
+                        quality = 5
+                    if 10_000_001 <= img_size:
+                        quality = 3
+
+                    file_extension = f'.{save_format}'
+                # case "JPEG" | "jpeg":
+                #     # Determine a suitable quality for the image.
+                #     # Determines the finished file size in bytes. Smaller is better.
+                #     if 500_000 >= img_size:
+                #         quality = 30
+                #     if 500_000 <= img_size <= 1000_000:
+                #         quality = 20
+                #     if 1_000_001 <= img_size <= 2_000_000:
+                #         quality = 10
+                #     if 2_000_001 <= img_size <= 10_000_000:
+                #         quality = 5
+                #     if 10_000_001 <= img_size:
+                #         quality = 3
+                #
+                #     file_extension = f'.{save_format.lower()}'
+                #
+                # case "PNG" | "png":
+                #     # Determine a suitable quality for the image.
+                #     # Determines the finished file size in bytes. Smaller is better.
+                #     if 500_000 >= img_size:
+                #         quality = 30
+                #     if 500_000 <= img_size <= 1000_000:
+                #         quality = 20
+                #     if 1_000_001 <= img_size <= 2_000_000:
+                #         quality = 10
+                #     if 2_000_001 <= img_size <= 10_000_000:
+                #         quality = 5
+                #     if 10_000_001 <= img_size:
+                #         quality = 3
+                #
+                #     file_extension = ".png"
+
+                case _:
+                    raise TypeError(
+                        f"Image save format must be of type WEBP, JPEG or PNG: {save_format} supplied",
+                    )
+
+        case _:
+            raise TypeError(
+                f"Image must be of type <class django.core.files.uploadedfile.UploadedFile>: {type(image)} supplied.",  # noqa: E501
+            )
+
+    # Create the new filename with correct extension to match the updated format
+    file_name = Path(image.__dict__["_name"]).with_suffix(file_extension).name
+
+    # Open the image as a pillow object to change format.
+    formatted_image = Image.open(image)
+    # Create an in memory buffer to save the image to.
+    image_buffer = io.BytesIO()
+    formatted_image.save(
+        image_buffer,
+        format=save_format,
+        quality=quality,
+        optimize=True,
+    )
+
+    updated_image = ImageFile(
+        io.BytesIO(image_buffer.getvalue()),
+        name=file_name,
+    )
+
+    # Close the buffer to free up memory.
+    image_buffer.close()
+
+    # Return a Django ImageFile with updated format.
+    # return updated_image
+
+
+    return formatted_image

--- a/django_ckeditors/static/django_ckeditors/app.js
+++ b/django_ckeditors/static/django_ckeditors/app.js
@@ -116,7 +116,8 @@ function getAddedNodes(recordList) {
         .filter(node => node.nodeType === 1);
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+
+function initializeDjCKEditors(element = document.body) {
     createEditors();
 
     if (typeof django === "object" && django.jQuery) {
@@ -143,4 +144,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Starts to observe the selected father element with the configured options
     observer.observe(mainContent, observerOptions);
+}
+
+
+// Expose the function for on-demand use
+window.initializeDjCKEditors = initializeDjCKEditors;
+
+
+
+document.addEventListener("DOMContentLoaded", () => {
+    initializeDjCKEditors();
+
 });

--- a/django_ckeditors/views.py
+++ b/django_ckeditors/views.py
@@ -42,8 +42,12 @@ def upload_image(request):
         except InvalidImageTypeError as e:
             return JsonResponse({"error": {"message": f"{e}"}})
         if form.is_valid():
-            url = handle_uploaded_image(request)
-            return JsonResponse({"url": url})
+            try:
+                url = handle_uploaded_image(request)
+                return JsonResponse({"url": url})
+            except TypeError as e:
+                error_msg = "The file you have supplied is invalid."
+                JsonResponse({"error": {"message": error_msg}})
         else:
             return JsonResponse({"error": form.errors})
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 project = "Django CKEditors"
 project_copyright = "2024, Mark Sevelj"

--- a/docs/source/how-to/quickstart.rst
+++ b/docs/source/how-to/quickstart.rst
@@ -57,16 +57,24 @@ Configuration
           },
       }
 
-3. **Add URLs to your `urls.py`**
+3. **Add `ckeditors` URL to your project root `urls.py`**
 
    .. code-block:: python
 
+      # Optional imports if using debug.
       from django.conf import settings
-      from django.conf.urls.static import static
+      from django.conf.urls.static import static 
 
-      urlpatterns += [
+      urlpatterns = [
         path("ckeditors/", include('django_ckeditors.urls'), name="ck-editors"),
-      ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+      ]
+
+      # Optional setting for local development.
+
+      if settings.DEBUG:
+          urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+|
 
 Using the Editor
 ----------------
@@ -141,9 +149,15 @@ Optional: Set this to True and only staff members are permitted to upload CKEdit
 
 * **DJ_CKE_IMAGE_URL_HANDLER:str = ""**
 
+Optional: Provide a custom image url handler. See below for the signature.
+
 |
 
-Optional: Provide a custom image url handler. See below for the signature.
+* **DJ_CKE_IMAGE_FORMATTER:str = ""**
+
+Optional: Provide a custom image format handler.
+
+|
 
 .. note::
 
@@ -156,6 +170,9 @@ Optional: Provide a custom image url handler. See below for the signature.
     if you return the url "images/cke/image_name.png"
 
     The image will be saved to "media/images/cke/image_name.png"
+
+|
+
 
 
 .. code-block:: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ keywords = ["CKEditor", "CKEditors", "Django"]
 license = {text = "BSD-3-Clause"}
 readme = "README.rst"
 requires-python = ">=3.10"
-version = "0.0.7"
+version = "0.0.8"
 
 authors = [
     {"name" = "Vladislav Khoboko", "email" = "vladislah@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "CKEditors for Django."
 keywords = ["CKEditor", "CKEditors", "Django"]
 license = {text = "BSD-3-Clause"}
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 version = "0.0.7"
 
 authors = [
@@ -20,8 +20,7 @@ classifiers = [
         "Development Status :: 2 - Pre-Alpha",
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.0",
+        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 5.0",
         "Intended Audience :: Developers",


### PR DESCRIPTION
If a developer wishes to use a custom image formatter this can
be done by providing a string path to the formatter.
Docs have been updated to reflect the new setting.

closes #49

closes #50