### PR TITLE
feat(image): Add unused image removal #77 

### DIFF
--- a/django_ckeditors/admin.py
+++ b/django_ckeditors/admin.py
@@ -1,0 +1,9 @@
+"""django-ckeditors Admin file."""
+
+from django.contrib import admin
+
+from .models import UnusedImageURLS
+
+# Register your tag_me models here.
+
+admin.site.register(UnusedImageURLS)

--- a/django_ckeditors/apps.py
+++ b/django_ckeditors/apps.py
@@ -10,6 +10,10 @@ class DjangoCKEditorsConfig(AppConfig):
     name = "django_ckeditors"
 
     def ready(self):
+         if not hasattr(settings, "DJ_CKE_BULK_CREATE_BATCH_SIZE"):
+            settings.DJ_CKE_BULK_CREATE_BATCH_SIZE: int = 50  # type: ignore[attr-defined]
+
+
         if not hasattr(settings, "DJ_CKE_CSRF_COOKIE_NAME"):
             settings.DJ_CKE_CSRF_COOKIE_NAME: str = settings.CSRF_COOKIE_NAME  # type: ignore[attr-defined]
 

--- a/django_ckeditors/apps.py
+++ b/django_ckeditors/apps.py
@@ -10,8 +10,6 @@ class DjangoCKEditorsConfig(AppConfig):
     name = "django_ckeditors"
 
     def ready(self):
-        # Unsure as to why this was used originally,
-        # but here it is just in case.
         if not hasattr(settings, "DJ_CKE_CSRF_COOKIE_NAME"):
             settings.DJ_CKE_CSRF_COOKIE_NAME: str = settings.CSRF_COOKIE_NAME  # type: ignore[attr-defined]
 
@@ -34,6 +32,12 @@ class DjangoCKEditorsConfig(AppConfig):
             )
         if not hasattr(settings, "DJ_CKE_FORMAT_IMAGE"):
             settings.DJ_CKE_FORMAT_IMAGE = True  # False: keep original formt and name.
+
+        # Either delete or store Images not in the editor.  These are
+        # images added and then removed from the editor. The image will
+        # persist in storage unless handled outside the editor.
+        if not hasattr(settings, "DJ_CKE_IMAGE_DELETION"):
+            settings.DJ_CKE_IMAGE_DELETION: bool = False  # type: ignore[attr-defined]
 
         if not hasattr(settings, "DJ_CKE_IMAGE_URL_HANDLER"):
             settings.DJ_CKE_IMAGE_URL_HANDLER: str = ""  # type: ignore[attr-defined]

--- a/django_ckeditors/models.py
+++ b/django_ckeditors/models.py
@@ -1,0 +1,62 @@
+"""django-ckeditors models"""
+
+from django.db import models
+from django.utils.translation import pgettext_lazy as _
+
+
+class UnusedImageURLS(models.Model):
+    """Image urls that are no longer referenced in a ckEditor"""
+
+    image_url = models.URLField(
+        max_length=255,
+        blank=True,
+        default="",
+        verbose_name=_(
+            "Verbose name",
+            "Image URL",
+        ),
+        help_text=_(
+            "Help text",
+            "The images url.",
+        ),
+    )
+
+    created = models.DateTimeField(
+        auto_now_add=True,
+        verbose_name=_("Verbose name", "Created"),
+        help_text=_("Help text", "The date and time when this record was created."),
+    )
+
+    deleted = models.DateTimeField(
+        null=True,
+        blank=True,
+        verbose_name=_("Verbose name", "Deleted"),
+        help_text=_(
+            "Help text",
+            "The date and time when this record was deleted (if applicable).",
+        ),
+    )
+
+    class Meta:
+        verbose_name = _(
+            "Verbose name",
+            "Django CKE Unused Images",
+        )
+        verbose_name_plural = _(
+            "Verbose name",
+            "Django CKE Unused Images",
+        )
+        app_label = "django_ckeditors"
+
+        constraints = [
+            models.UniqueConstraint(
+                fields=[
+                    "image_url",
+                ],
+                name="djcke_image_url_no_duplicates",
+                violation_error_message="Django CKeditor removed image url may not be duplicated.",
+            )
+        ]
+
+    def __str__(self):
+        return str(self.image_url)

--- a/django_ckeditors/static/django_ckeditors/app.js
+++ b/django_ckeditors/static/django_ckeditors/app.js
@@ -1,8 +1,9 @@
 import ClassicEditor from './src/ckeditor';
 import './src/override-django.css';
 
-
 let editors = [];
+// Store image URLs for each editor, placeholder for future useage.
+const editorImageUrls = new Map(); 
 
 function getCookie(name) {
     let cookieValue = null;
@@ -19,30 +20,11 @@ function getCookie(name) {
     return cookieValue;
 }
 
-/**
- * Checks whether the element or its children match the query and returns
- * an array with the matches.
- * 
- * @param {!HTMLElement} element
- * @param {!string} query
- * 
- * @returns {array.<HTMLElement>}
- */
-function resolveElementArray(element, query) {
-    return element.matches(query) ? [element] : [...element.querySelectorAll(query)];
-}
 
-/**
- * This function initializes the CKEditor inputs within an optional element and
- * assigns properties necessary for the correct operation
- * 
- * @param {HTMLElement} [element=document.body] - The element to search for elements
- * 
- * @returns {void}
- */
 function createEditors(element = document.body) {
+
     // Find all elements within the specified container (or entire document body)
-    // that have the class 'django_ckeditors' (these are our potential CKEditor targets).
+    // that have the class 'django_ckeditors' (these are our CKEditor targets).
     const allEditors = resolveElementArray(element, '.django_ckeditors');
 
     allEditors.forEach(editorEl => {
@@ -56,20 +38,24 @@ function createEditors(element = document.body) {
         }
         const script_id = `${editorEl.id}_script`;
         editorEl.nextSibling.remove();
-        const upload_url = element.querySelector(
+
+        const upload_image_url = element.querySelector(
             `#${script_id}-ck-editors-upload-url`
-        ).getAttribute('data-upload-url');
+        ).getAttribute('data-upload-image-url');
+
         const csrf_cookie_name = element.querySelector(
             `#${script_id}-ck-editors-upload-url`
         ).getAttribute('data-csrf_cookie_name');
-        const data_extra = element.querySelector(
+
+        const data_extra = JSON.stringify(JSON.parse(element.querySelector(
             `#${script_id}-ck-editors-upload-url`
-        ).getAttribute('data-extra');
+        ).getAttribute('data-extra')));
+
         const labelElement = element.querySelector(`[for$="${editorEl.id}"]`);
         if (labelElement) {
             labelElement.style.float = 'none';
         }
-        console.log('EXTRA DATA', data_extra)
+        //console.log('EXTRA DATA', data_extra)
 
         const config = JSON.parse(
             element.querySelector(`#${script_id}-span`).textContent,
@@ -83,31 +69,106 @@ function createEditors(element = document.body) {
             }
         );
         config.simpleUpload = {
-            'uploadUrl': upload_url, 
+            'uploadUrl': upload_image_url, 
             'headers': {
                 'X-CSRFToken': getCookie(csrf_cookie_name),
                 'X-Data-Extra': data_extra,
             }
         };
-        ClassicEditor.create(
-            editorEl,
-            config
-        ).then(editor => {
+
+
+        ClassicEditor.create(editorEl, config)
+            .then(editor => {
+                //  WordCount plugin handling
                 if (editor.plugins.has('WordCount')) {
                     const wordCountPlugin = editor.plugins.get('WordCount');
                     const wordCountWrapper = element.querySelector(`#${script_id}-word-count`);
                     wordCountWrapper.innerHTML = '';
                     wordCountWrapper.appendChild(wordCountPlugin.wordCountContainer);
-                }
+                };
+                // Extract initial image URLs for this editor
+                const previousImageUrls = extractImageUrls(editor.getData());
+                editorImageUrls.set(editor, previousImageUrls);
+
+                // Listen for content changes
+                editor.model.document.on('change:data', () => {
+                    const currentContent = editor.getData();
+                    const currentImageUrls = extractImageUrls(currentContent);
+
+                    // Compare and identify removed images
+                    const removedImages = findRemovedImages(previousImageUrls, currentImageUrls);
+                    removedImages.forEach(imageUrl => {
+                        console.log('Image removed from', editor, ':', imageUrl);
+                        //sendRemovedImageToServer(imageUrl, upload_unused_image_url); // Pass the URL
+                    });
+
+                    // Update the stored URLs for the next comparison
+                    editorImageUrls.set(editor, currentImageUrls); 
+                });
+
                 editors.push(editor);
-            }).catch(error => {
-                console.error((error));
+            })
+            .catch(error => {
+                console.error(error);
             });
+
         editorEl.setAttribute('data-processed', '1');
     });
 
-    window.editors = editors;
+    window.editors = editors; 
     window.ClassicEditor = ClassicEditor;
+}
+
+/**
+ * Checks whether the element or its children match the query and returns
+ * an array with the matches.
+ * 
+ * @param {!HTMLElement} element
+ * @param {!string} query
+ * 
+ * @returns {array.<HTMLElement>}
+ */
+function resolveElementArray(element, query) {
+    return element.matches(query) ? [element] : [...element.querySelectorAll(query)];
+}
+
+
+// Function to extract image URLs from CKEditor content (HTML string)
+function extractImageUrls(content) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(content, 'text/html');
+    const images = doc.querySelectorAll('img');
+
+    return Array.from(images).map(img => img.src);
+}
+
+// Function to find removed image URLs by comparing two arrays
+function findRemovedImages(oldImageUrls, newImageUrls) {
+    return oldImageUrls.filter(imageUrl => !newImageUrls.includes(imageUrl));
+}
+
+// Function to send removed image URLs to the server
+function sendRemovedImageToServer(imageUrl, endpointUrl) {
+    fetch(endpointUrl, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json', 
+            'X-CSRFToken': getCookie(csrf_cookie_name),
+        },
+        body: JSON.stringify({ imageUrl }),
+    })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            return response.json(); // Or handle the response as needed by your server
+        })
+        .then(data => {
+            console.log('Server response:', data);
+        })
+        .catch(error => {
+            console.error('Error sending image URL:', error);
+        });
 }
 
 /**

--- a/django_ckeditors/templates/django_ckeditors/widget.html
+++ b/django_ckeditors/templates/django_ckeditors/widget.html
@@ -9,7 +9,7 @@
 <input 
         type="hidden" 
         id="{{script_id}}-ck-editors-upload-url" 
-        data-upload-url="{{upload_url}}"
+        data-upload-image-url="{{upload_image_url}}"
         data-csrf_cookie_name="{{ csrf_cookie_name }}"
         data-extra="{{data_extra}}"
 

--- a/django_ckeditors/templates/django_ckeditors/widget.html
+++ b/django_ckeditors/templates/django_ckeditors/widget.html
@@ -10,6 +10,7 @@
         type="hidden" 
         id="{{script_id}}-ck-editors-upload-url" 
         data-upload-image-url="{{upload_image_url}}"
+        data-upload-unused-image-url="{{upload_unused_image_url}}"
         data-csrf_cookie_name="{{ csrf_cookie_name }}"
         data-extra="{{data_extra}}"
 

--- a/django_ckeditors/urls.py
+++ b/django_ckeditors/urls.py
@@ -1,16 +1,19 @@
 from django.urls import path
 
-from . import views
+from django_ckeditors.views import (
+    process_unused_image_urls,
+    upload_image,
+)
 
 urlpatterns = [
     path(
         "image_upload/",
-        views.upload_image,
+        upload_image,
         name="ck_editors_upload_image",
     ),
-    # path(
-    #     "unused_image_upload/",
-    #     views.upload_image,
-    #     name="ck_editors_unused_upload_image",
-    # ),
+    path(
+        "unused_image_url/",
+        process_unused_image_urls,
+        name="ck_editors_unused_image_url",
+    ),
 ]

--- a/django_ckeditors/urls.py
+++ b/django_ckeditors/urls.py
@@ -3,5 +3,14 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("image_upload/", views.upload_image, name="ck_editors_upload_image"),
+    path(
+        "image_upload/",
+        views.upload_image,
+        name="ck_editors_upload_image",
+    ),
+    # path(
+    #     "unused_image_upload/",
+    #     views.upload_image,
+    #     name="ck_editors_unused_upload_image",
+    # ),
 ]

--- a/django_ckeditors/widgets.py
+++ b/django_ckeditors/widgets.py
@@ -147,7 +147,7 @@ class CKEditorsWidget(forms.Widget):
         context["config"] = self.config
         context["script_id"] = f'{attrs["id"]}_script'
         context["upload_image_url"] = reverse("ck_editors_upload_image")
-        context["upload_unused_image_url"] = reverse("ck_editors_upload_image")
+        context["upload_unused_image_url"] = reverse("ck_editors_unused_image_url")
         context["csrf_cookie_name"] = settings.DJ_CKE_CSRF_COOKIE_NAME
         context["data_extra"] = json.dumps(self.data_extra)
         # .. NOTE: Config errors probably should not be sent to the end user.

--- a/django_ckeditors/widgets.py
+++ b/django_ckeditors/widgets.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import logging
 import json
+import logging
+
 from django import forms, get_version
 from django.conf import settings
 from django.forms.renderers import get_default_renderer
@@ -145,7 +146,8 @@ class CKEditorsWidget(forms.Widget):
 
         context["config"] = self.config
         context["script_id"] = f'{attrs["id"]}_script'
-        context["upload_url"] = reverse("ck_editors_upload_image")
+        context["upload_image_url"] = reverse("ck_editors_upload_image")
+        context["upload_unused_image_url"] = reverse("ck_editors_upload_image")
         context["csrf_cookie_name"] = settings.DJ_CKE_CSRF_COOKIE_NAME
         context["data_extra"] = json.dumps(self.data_extra)
         # .. NOTE: Config errors probably should not be sent to the end user.

--- a/django_ckeditors/widgets.py
+++ b/django_ckeditors/widgets.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-
+import json
 from django import forms, get_version
 from django.conf import settings
 from django.forms.renderers import get_default_renderer
@@ -147,7 +147,7 @@ class CKEditorsWidget(forms.Widget):
         context["script_id"] = f'{attrs["id"]}_script'
         context["upload_url"] = reverse("ck_editors_upload_image")
         context["csrf_cookie_name"] = settings.DJ_CKE_CSRF_COOKIE_NAME
-        context["data_extra"] = self.data_extra
+        context["data_extra"] = json.dumps(self.data_extra)
         # .. NOTE: Config errors probably should not be sent to the end user.
         # if self._config_errors:
         #   context["errors"] = ErrorList(self._config_errors) #pylint:disable=commented-out code


### PR DESCRIPTION
This commit provides tools to extract images that have been
uploaded in a ckeditor, and later removed.  The options are
to delete the images (default), or store them in the database
for processing at a later time.

closes #77