### PR TITLE
feat(mode): Add global readonly enable/disable events #94

### DIFF
--- a/django_ckeditors/static/django_ckeditors/src/override-django.css
+++ b/django_ckeditors/static/django_ckeditors/src/override-django.css
@@ -1,3 +1,10 @@
+.ck .ck-toolbar {
+    transition-property: height;
+    transition-duration: 300ms; 
+    transition-timing-function: ease-in-out;
+    overflow: hidden;
+    will-change: height; /* For potential performance improvement */
+}
 /** Todo list **/
 
 .ck .todo-list input {


### PR DESCRIPTION
The two new events have listeners in the create.  If either is triggered the ckeditor window will transition to the new state. There is an option to hide the toolbar when in readonly,set using `hideToolbar`.

closes #94